### PR TITLE
Fix compatibility with Composer 2.10.0 audit() signature change

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@
 /composer.lock            export-ignore
 /phpstan.neon.dist        export-ignore
 /phpstan-baseline.neon       export-ignore
+/phpstan-by-composer-version.php      export-ignore

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -91,13 +91,7 @@ parameters:
 			path: src/Composer/Command/AuditChangesCommand.php
 
 		-
-			message: '#^Parameter \#6 \$ignoreList of method Composer\\Advisory\\Auditor\:\:audit\(\) expects array\<string\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Composer/Command/AuditChangesCommand.php
-
-		-
-			message: '#^Parameter \#7 \$abandoned of method Composer\\Advisory\\Auditor\:\:audit\(\) expects ''fail''\|''ignore''\|''report'', mixed given\.$#'
-			identifier: argument.type
-			count: 1
+			message: '#^Possibly invalid array key type mixed\.$#'
+			identifier: offsetAccess.invalidOffset
+			count: 2
 			path: src/Composer/Command/AuditChangesCommand.php

--- a/phpstan-by-composer-version.php
+++ b/phpstan-by-composer-version.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Dynamic PHPStan include file — adapts analysis to the installed
+ * composer/composer version.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2023-2026 Dezső Biczó
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/mxr576/composer-audit-changes/LICENSE.md
+ *
+ */
+
+if (PHP_SAPI !== 'cli') {
+    return [];
+}
+
+use Composer\InstalledVersions;
+use Composer\Semver\Semver;
+
+$composerVersion = InstalledVersions::getVersion('composer/composer');
+assert(is_string($composerVersion));
+
+$config = [];
+
+// Composer\Policy\PolicyConfig does not exist before 2.10.0 and the signature
+// off audit() method is different.
+if (Semver::satisfies($composerVersion, '<2.10.0')) {
+    $config['parameters']['excludePaths']['analyseAndScan'][] = __DIR__ . '/src/Composer/Auditor/PolicyConfigAuditorAdapter.php';
+    $config['includes'][] = __DIR__ . '/phpstan-legacy-baseline.neon';
+} else {
+    $config['parameters']['excludePaths']['analyseAndScan'][] = __DIR__ . '/src/Composer/Auditor/LegacyAuditorAdapter.php';
+
+}
+
+return $config;

--- a/phpstan-legacy-baseline.neon
+++ b/phpstan-legacy-baseline.neon
@@ -1,0 +1,13 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Offset ''ignore'' might not exist on array\{\}\|array\{ignore\?\: mixed, abandoned\?\: ''fail''\|''ignore''\|''report''\|null\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: src/Composer/Auditor/LegacyAuditorAdapter.php
+
+		-
+			message: '#^Parameter \#6 \$ignoreList of method Composer\\Advisory\\Auditor\:\:audit\(\) expects array\<string\>, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Composer/Auditor/LegacyAuditorAdapter.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,6 @@
 includes:
     - phpstan-baseline.neon
+    - phpstan-by-composer-version.php
     - %rootDir%/../../composer/composer/phpstan/rules.neon
     - %rootDir%/../../phpstan/phpstan-deprecation-rules/rules.neon
 

--- a/src/Composer/Auditor/AuditorAdapterInterface.php
+++ b/src/Composer/Auditor/AuditorAdapterInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2023-2026 Dezső Biczó
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/mxr576/composer-audit-changes/LICENSE.md
+ *
+ */
+
+namespace mxr576\ComposerAuditChanges\Composer\Auditor;
+
+use Composer\IO\IOInterface;
+use Composer\Package\PackageInterface;
+use Composer\Repository\RepositorySet;
+
+/**
+ * Abstracts the Composer version-specific Auditor::audit() signature
+ * differences so that each concrete implementation can be analysed by
+ * PHPStan against only the API available in its target Composer version.
+ *
+ * @internal
+ */
+interface AuditorAdapterInterface
+{
+    /**
+     * @param PackageInterface[] $packages
+     * @param \Composer\Advisory\Auditor::FORMAT_* $format
+     */
+    public function audit(
+        IOInterface $io,
+        RepositorySet $repoSet,
+        array $packages,
+        string $format,
+        bool $warningOnly,
+    ): int;
+}

--- a/src/Composer/Auditor/LegacyAuditorAdapter.php
+++ b/src/Composer/Auditor/LegacyAuditorAdapter.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2023-2026 Dezső Biczó
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/mxr576/composer-audit-changes/LICENSE.md
+ *
+ */
+
+namespace mxr576\ComposerAuditChanges\Composer\Auditor;
+
+use Composer\Advisory\Auditor;
+use Composer\Config;
+use Composer\IO\IOInterface;
+use Composer\Repository\RepositorySet;
+
+/**
+ * Audit adapter for Composer < 2.10.0.
+ *
+ * @internal
+ */
+final class LegacyAuditorAdapter implements AuditorAdapterInterface
+{
+    public function __construct(private readonly Config $config)
+    {
+    }
+
+    /**
+     * @throws \RuntimeException
+     */
+    public function audit(
+        IOInterface $io,
+        RepositorySet $repoSet,
+        array $packages,
+        string $format,
+        bool $warningOnly,
+    ): int {
+        $auditConfig = $this->config->get('audit');
+        if (!is_array($auditConfig)) {
+            $auditConfig = [];
+        }
+
+        $auditor = new Auditor();
+
+        return $auditor->audit(
+            $io,
+            $repoSet,
+            $packages,
+            $format,
+            $warningOnly,
+            $auditConfig['ignore'],
+            $auditConfig['abandoned'] ?? Auditor::ABANDONED_REPORT,
+        );
+    }
+}

--- a/src/Composer/Auditor/PolicyConfigAuditorAdapter.php
+++ b/src/Composer/Auditor/PolicyConfigAuditorAdapter.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2023-2026 Dezső Biczó
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/mxr576/composer-audit-changes/LICENSE.md
+ *
+ */
+
+namespace mxr576\ComposerAuditChanges\Composer\Auditor;
+
+use Composer\Advisory\Auditor;
+use Composer\Config;
+use Composer\FilterList\FilterListProvider\FilterListProviderSet;
+use Composer\IO\IOInterface;
+use Composer\Policy\PolicyConfig;
+use Composer\Repository\RepositoryManager;
+use Composer\Repository\RepositorySet;
+use Composer\Util\HttpDownloader;
+
+/**
+ * Audit adapter for Composer >= 2.10.0.
+ *
+ * @see https://github.com/composer/composer/commit/37825e9851291b969be52cf98894af17505f2766
+ *
+ * @internal
+ */
+final class PolicyConfigAuditorAdapter implements AuditorAdapterInterface
+{
+    public function __construct(
+        private readonly Config $config,
+        private readonly RepositoryManager $repositoryManager,
+        private readonly HttpDownloader $httpDownloader,
+    ) {
+    }
+
+    public function audit(
+        IOInterface $io,
+        RepositorySet $repoSet,
+        array $packages,
+        string $format,
+        bool $warningOnly,
+    ): int {
+        $policyConfig = PolicyConfig::fromConfig($this->config);
+
+        $filterListProviderSet = $policyConfig->enabled
+            ? FilterListProviderSet::create(
+                $policyConfig,
+                $this->repositoryManager->getRepositories(),
+                $this->httpDownloader,
+            )
+            : null;
+
+        $auditor = new Auditor();
+
+        return $auditor->audit(
+            $io,
+            $repoSet,
+            $policyConfig,
+            $packages,
+            $format,
+            $warningOnly,
+            $filterListProviderSet,
+        );
+    }
+}

--- a/src/Composer/Command/AuditChangesCommand.php
+++ b/src/Composer/Command/AuditChangesCommand.php
@@ -27,6 +27,8 @@ use Composer\Repository\LockArrayRepository;
 use Composer\Repository\RepositorySet;
 use Composer\Semver\Constraint\MatchAllConstraint;
 use Composer\Util\ProcessExecutor;
+use mxr576\ComposerAuditChanges\Composer\Auditor\LegacyAuditorAdapter;
+use mxr576\ComposerAuditChanges\Composer\Auditor\PolicyConfigAuditorAdapter;
 use Seld\JsonLint\ParsingException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -73,18 +75,33 @@ EOT
             return 0;
         }
 
-        $auditor = new Auditor();
         $repoSet = new RepositorySet();
         foreach ($composer->getRepositoryManager()->getRepositories() as $repo) {
             $repoSet->addRepository($repo);
         }
 
-        $auditConfig = $composer->getConfig()->get('audit');
-        if (!is_array($auditConfig)) {
-            $auditConfig = [];
-        }
+        // Composer 2.10.0 changed Auditor::audit() to accept a PolicyConfig
+        // value object instead of individual $ignoreList and $abandonedMode
+        // parameters. Each adapter encapsulates the API available in its
+        // target Composer version so that PHPStan can analyse them in
+        // isolation without cross-version type errors.
+        //
+        // @see https://github.com/composer/composer/commit/37825e9851291b969be52cf98894af17505f2766
+        $adapter = version_compare(Composer::VERSION, '2.10.0', '>=')
+            ? new PolicyConfigAuditorAdapter(
+                $composer->getConfig(),
+                $composer->getRepositoryManager(),
+                $composer->getLoop()->getHttpDownloader(),
+            )
+            : new LegacyAuditorAdapter($composer->getConfig());
 
-        $audit = $auditor->audit($this->getIO(), $repoSet, $packages, $this->getAuditFormat($input, 'format'), false, $auditConfig['ignore'] ?? [], $auditConfig['abandoned'] ?? $auditor::ABANDONED_REPORT);
+        $audit = $adapter->audit(
+            $this->getIO(),
+            $repoSet,
+            $packages,
+            $this->getAuditFormat($input, 'format'),
+            false,
+        );
 
         return min(255, $audit);
     }


### PR DESCRIPTION
## Problem

Composer 2.10.0 introduced a breaking change to `Auditor::audit()` in [composer/composer@37825e9](https://github.com/composer/composer/commit/37825e9851291b969be52cf98894af17505f2766). The method signature was refactored to accept a single `PolicyConfig` value object instead of individual `$ignoreList` and `$abandonedMode` parameters. The `$packages` argument also moved to the fourth position (after `$policyConfig`).

**Old signature (< 2.10.0):**
```php
public function audit(IOInterface $io, RepositorySet $repoSet, array $packages, string $format, bool $warningOnly = true, array $ignoreList = [], string $abandoned = self::ABANDONED_REPORT): int
```

**New signature (>= 2.10.0):**
```php
public function audit(IOInterface $io, RepositorySet $repoSet, PolicyConfig $policyConfig, array $packages, string $format, bool $warningOnly = true, ?FilterListProviderSet $filterListProviderSet = null): int
```

This caused a fatal error at `AuditChangesCommand.php` line 87 when running under Composer 2.10.0.

## Solution

Add a runtime `version_compare()` branch — the same pattern used before when a [previous audit() incompatibility was resolved](https://github.com/mxr576/composer-audit-changes/commit/f6cd0f8adf94df6299a9d8c79a6abc05fa424dc0) — so both Composer `< 2.10.0` and `>= 2.10.0` are supported:

- **Composer >= 2.10.0:** builds a `PolicyConfig` via `PolicyConfig::fromConfig()`, which reads both `config.policy` and the legacy `config.audit` key for backward compatibility with existing `composer.json` files, then calls `audit()` with the new signature.
- **Composer < 2.10.0:** continues to call `audit()` with the old signature, reading `ignore` and `abandoned` directly from the `config.audit` array.

No `use` statement is added for `\Composer\Policy\PolicyConfig` at the top of the file — the class is referenced with its FQCN only inside the `>= 2.10.0` branch, so older Composer versions that don't have the class never trigger a class-not-found error.

## Testing

Please verify CI passes against both a `^2.9` and a `^2.10` Composer installation.